### PR TITLE
Fix/type search

### DIFF
--- a/backend/aethel_db/views/detail.py
+++ b/backend/aethel_db/views/detail.py
@@ -67,11 +67,9 @@ class AethelDetailResponse:
             AETHEL_DETAIL_STATUS_CODES[self.error] if self.error else status.HTTP_200_OK
         )
 
-        result_data = self.result.serialize() if self.result else None
-
         return JsonResponse(
             {
-                "result": result_data if self.result else None,
+                "result": self.result.serialize() if self.result else None,
                 "error": self.error,
             },
             status=status_code,

--- a/backend/aethel_db/views/detail.py
+++ b/backend/aethel_db/views/detail.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from django.http import HttpRequest, JsonResponse
 from rest_framework import status
 from rest_framework.views import APIView
-from spindle.utils import serialize_phrases_with_infix_notation
+from spindle.utils import serialize_phrases
 from aethel.frontend import Sample
 
 from aethel_db.models import dataset
@@ -59,7 +59,7 @@ class AethelDetailResponse:
             name=sample.name,
             term=str(sample.proof.term),
             subset=sample.subset,
-            phrases=serialize_phrases_with_infix_notation(sample.lexical_phrases),
+            phrases=serialize_phrases(sample.lexical_phrases),
         )
 
     def json_response(self) -> JsonResponse:

--- a/backend/spindle/utils.py
+++ b/backend/spindle/utils.py
@@ -2,13 +2,13 @@ from aethel.frontend import LexicalPhrase
 from aethel.mill.types import type_prefix, type_repr
 
 
-def serialize_phrases_with_infix_notation(
+def serialize_phrases(
     lexical_phrases: list[LexicalPhrase],
 ) -> list[dict[str, str]]:
     """
     Serializes a list of LexicalPhrases in a human-readable infix notation that is already available in Æthel in Type.__repr__ or type_repr(). This is used to display the types in the frontend.
 
-    The standard JSON serialization of phrases uses a prefix notation for types, which is good for data-exchange purposes (easier parsing) but less ideal for human consumption. This notation will be used to query.
+    The standard JSON serialization of phrases uses a prefix notation for types, which is good for data-exchange purposes (easier parsing) but less ideal for human consumption. This notation is used to query.
     """
     return [
         dict(

--- a/backend/spindle/utils.py
+++ b/backend/spindle/utils.py
@@ -1,12 +1,20 @@
 from aethel.frontend import LexicalPhrase
+from aethel.mill.types import type_prefix, type_repr
 
 
 def serialize_phrases_with_infix_notation(
     lexical_phrases: list[LexicalPhrase],
 ) -> list[dict[str, str]]:
     """
-    Serializes a list of LexicalPhrases in a human-readable infix notation that is already available in Æthel in Type.__repr__.
+    Serializes a list of LexicalPhrases in a human-readable infix notation that is already available in Æthel in Type.__repr__ or type_repr(). This is used to display the types in the frontend.
 
-    The standard JSON serialization of phrases uses a prefix notation for types, which is good for data-exchange purposes (easier parsing) but less ideal for human consumption.
+    The standard JSON serialization of phrases uses a prefix notation for types, which is good for data-exchange purposes (easier parsing) but less ideal for human consumption. This notation will be used to query.
     """
-    return [dict(phrase.json(), type=repr(phrase.type)) for phrase in lexical_phrases]
+    return [
+        dict(
+            phrase.json(),
+            display_type=type_repr(phrase.type),
+            type=type_prefix(phrase.type),
+        )
+        for phrase in lexical_phrases
+    ]

--- a/backend/spindle/views.py
+++ b/backend/spindle/views.py
@@ -53,13 +53,8 @@ class SpindleResponse:
         # TODO: set HTTP error code when error is not None
 
         # Convert display_type to displayType for frontend.
-        camelized = [
-            {
-                **{k: v for k, v in phrase.items() if k != "display_type"},
-                "displayType": phrase["display_type"],
-            }
-            for phrase in self.lexical_phrases
-        ]
+        for phrase in self.lexical_phrases:
+            phrase["displayType"] = phrase.pop("display_type")
 
         return JsonResponse(
             {
@@ -68,7 +63,7 @@ class SpindleResponse:
                 "redirect": self.redirect,
                 "error": self.error.value if self.error else None,
                 "term": self.term,
-                "lexical_phrases": camelized,
+                "lexical_phrases": self.lexical_phrases,
                 "proof": self.proof,
             }
         )

--- a/backend/spindle/views.py
+++ b/backend/spindle/views.py
@@ -22,14 +22,13 @@ from aethel.frontend import (
     serial_proof_to_json,
 )
 
-from spindle.utils import serialize_phrases_with_infix_notation
+from spindle.utils import serialize_phrases
 
 http = urllib3.PoolManager()
 
 
 # Output mode
 Mode = Literal["latex", "pdf", "overleaf", "term-table", "proof"]
-
 
 
 class SpindleErrorSource(Enum):
@@ -193,7 +192,7 @@ class SpindleView(View):
     def term_table_response(self, parsed: ParserResponse) -> JsonResponse:
         """Return the term and the lexical phrases as a JSON response."""
 
-        phrases = serialize_phrases_with_infix_notation(parsed.lexical_phrases)
+        phrases = serialize_phrases(parsed.lexical_phrases)
         return SpindleResponse(
             term=str(parsed.proof.term),
             lexical_phrases=phrases,
@@ -210,10 +209,10 @@ def spindle_status():
     try:
         r = http.request(
             method="GET",
-            url=settings.SPINDLE_URL + '/status/',
+            url=settings.SPINDLE_URL + "/status/",
             headers={"Content-Type": "application/json"},
             timeout=1,
-            retries=False
+            retries=False,
         )
         return r.status < 400
     except Exception:

--- a/backend/spindle/views.py
+++ b/backend/spindle/views.py
@@ -51,6 +51,16 @@ class SpindleResponse:
 
     def json_response(self) -> JsonResponse:
         # TODO: set HTTP error code when error is not None
+
+        # Convert display_type to displayType for frontend.
+        camelized = [
+            {
+                **{k: v for k, v in phrase.items() if k != "display_type"},
+                "displayType": phrase["display_type"],
+            }
+            for phrase in self.lexical_phrases
+        ]
+
         return JsonResponse(
             {
                 "latex": self.latex,
@@ -58,7 +68,7 @@ class SpindleResponse:
                 "redirect": self.redirect,
                 "error": self.error.value if self.error else None,
                 "term": self.term,
-                "lexical_phrases": self.lexical_phrases,
+                "lexical_phrases": camelized,
                 "proof": self.proof,
             }
         )

--- a/frontend/src/app/sample/sample.component.html
+++ b/frontend/src/app/sample/sample.component.html
@@ -36,7 +36,7 @@
                 <span *ngFor="let item of phrase.items">{{ item.word }} </span>
             </td>
             <td>
-                <span class="proof" [innerHtml]="phrase.type | proof"></span>
+                <span class="proof" [innerHtml]="phrase.displayType | proof"></span>
             </td>
             <td>
                 @if (showButtons(phrase.items)) {

--- a/frontend/src/app/sample/sample.component.spec.ts
+++ b/frontend/src/app/sample/sample.component.spec.ts
@@ -10,14 +10,15 @@ import {
 import {
     AethelDetail,
     AethelDetailError,
-    LexicalPhrase,
+    AethelDetailPhrase,
 } from "../shared/types";
 import { By } from "@angular/platform-browser";
 import { ProofPipe } from "../shared/pipes/proof.pipe";
 import { FontAwesomeModule } from "@fortawesome/angular-fontawesome";
 
-const fakePhrase: LexicalPhrase = {
+const fakePhrase: AethelDetailPhrase = {
     type: "cheese->tosti",
+    displayType: "cheese -> tosti",
     items: [
         {
             word: "cheeses",
@@ -71,7 +72,7 @@ describe("SampleComponent", () => {
 
     it("should construct a valid route for word search", () => {
         const spy = spyOn(router, "navigate");
-        component.searchAethel(fakePhrase, 'word');
+        component.searchAethel(fakePhrase, "word");
         expect(spy).toHaveBeenCalledOnceWith(["/aethel"], {
             queryParams: { word: "cheeses" },
         });
@@ -79,7 +80,7 @@ describe("SampleComponent", () => {
 
     it("should construct a valid route for type search", () => {
         const spy = spyOn(router, "navigate");
-        component.searchAethel(fakePhrase, 'type');
+        component.searchAethel(fakePhrase, "type");
         expect(spy).toHaveBeenCalledOnceWith(["/aethel"], {
             queryParams: { type: "cheese->tosti" },
         });
@@ -87,7 +88,7 @@ describe("SampleComponent", () => {
 
     it("should construct a valid route for word and type search", () => {
         const spy = spyOn(router, "navigate");
-        component.searchAethel(fakePhrase, 'word-and-type');
+        component.searchAethel(fakePhrase, "word-and-type");
         expect(spy).toHaveBeenCalledOnceWith(["/aethel"], {
             queryParams: { word: "cheeses", type: "cheese->tosti" },
         });

--- a/frontend/src/app/sample/sample.component.ts
+++ b/frontend/src/app/sample/sample.component.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 import { ActivatedRoute, Params, Router } from "@angular/router";
 import { AethelApiService } from "../shared/services/aethel-api.service";
 import { map } from "rxjs";
-import { AethelMode, LexicalPhrase } from "../shared/types";
+import { AethelMode, AethelDetailPhrase } from "../shared/types";
 import { isNonNull } from "../shared/operators/IsNonNull";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { Location } from "@angular/common";
@@ -31,12 +31,12 @@ export class SampleComponent {
         private location: Location,
     ) {}
 
-    public searchAethel(phrase: LexicalPhrase, mode: AethelMode): void {
+    public searchAethel(phrase: AethelDetailPhrase, mode: AethelMode): void {
         const queryParams = this.formatQueryParams(phrase, mode);
         this.router.navigate(["/aethel"], { queryParams });
     }
 
-    public showButtons(items: LexicalPhrase["items"]): boolean {
+    public showButtons(items: AethelDetailPhrase["items"]): boolean {
         // Buttons are hidden if the phrase contains too few characters.
         const combined = items.map((item) => item.word).join(" ");
         return combined.length > 2;
@@ -46,7 +46,10 @@ export class SampleComponent {
         this.location.back();
     }
 
-    private formatQueryParams(phrase: LexicalPhrase, mode: AethelMode): Params {
+    private formatQueryParams(
+        phrase: AethelDetailPhrase,
+        mode: AethelMode,
+    ): Params {
         const queryParams: Params = {};
         if (mode === "word" || mode === "word-and-type") {
             queryParams["word"] = phrase.items

--- a/frontend/src/app/shared/types.ts
+++ b/frontend/src/app/shared/types.ts
@@ -20,9 +20,10 @@ type LexicalItem = {
     lemma: string;
 };
 
-export type LexicalPhrase = {
+export type AethelDetailPhrase = {
     items: LexicalItem[];
     type: string;
+    displayType: string;
 };
 
 // Should correspond with SpindleResponse dataclass in backend.
@@ -32,7 +33,7 @@ export interface SpindleReturn {
     pdf: string | null;
     redirect: string | null;
     term: string | null;
-    lexical_phrases: LexicalPhrase[];
+    lexical_phrases: AethelDetailPhrase[];
     proof: Record<string, unknown> | null;
 }
 
@@ -49,11 +50,11 @@ export interface AethelListLexicalItem {
 }
 
 export interface AethelListPhrase {
-    items: AethelListLexicalItem[]
+    items: AethelListLexicalItem[];
 }
 
 export interface AethelListResult {
-    phrase: AethelListPhrase
+    phrase: AethelListPhrase;
     type: string;
     displayType: string;
     sampleCount: number;
@@ -76,7 +77,7 @@ export interface AethelDetailResult {
     name: string;
     term: string;
     subset: string;
-    phrases: LexicalPhrase[];
+    phrases: AethelDetailPhrase[];
 }
 
 export interface AethelDetail {

--- a/frontend/src/app/spindle/spindle.component.html
+++ b/frontend/src/app/spindle/spindle.component.html
@@ -73,7 +73,7 @@
             <td>
                 <span *ngFor="let item of phrase.items">{{ item.word }} </span>
             </td>
-            <td [innerHtml]="phrase.type | proof"></td>
+            <td [innerHtml]="phrase.displayType | proof"></td>
         </tr>
     </table>
 </div>

--- a/frontend/src/app/spindle/spindle.component.ts
+++ b/frontend/src/app/spindle/spindle.component.ts
@@ -5,7 +5,7 @@ import { ErrorHandlerService } from "../shared/services/error-handler.service";
 import { AlertService } from "../shared/services/alert.service";
 import { AlertType } from "../shared/components/alert/alert.component";
 import { faDownload, faCopy } from "@fortawesome/free-solid-svg-icons";
-import { LexicalPhrase, SpindleMode } from "../shared/types";
+import { AethelDetailPhrase, SpindleMode } from "../shared/types";
 import { SpindleApiService } from "../shared/services/spindle-api.service";
 import { Subject, filter, map, share, switchMap, takeUntil, timer } from "rxjs";
 import { StatusService } from "../shared/services/status.service";
@@ -26,7 +26,7 @@ export class SpindleComponent implements OnInit {
     });
     term: string | null = null;
     textOutput: TextOutput | null = null;
-    lexicalPhrases: LexicalPhrase[] = [];
+    lexicalPhrases: AethelDetailPhrase[] = [];
     loading$ = this.apiService.loading$;
 
     faCopy = faCopy;
@@ -37,8 +37,8 @@ export class SpindleComponent implements OnInit {
     spindleReady$ = timer(0, 5000).pipe(
         takeUntil(this.stopStatus$),
         switchMap(() => this.statusService.get()),
-        map(status => status.spindle),
-        share()
+        map((status) => status.spindle),
+        share(),
     );
 
     constructor(
@@ -46,14 +46,16 @@ export class SpindleComponent implements OnInit {
         private alertService: AlertService,
         private errorHandler: ErrorHandlerService,
         private destroyRef: DestroyRef,
-        private statusService: StatusService
+        private statusService: StatusService,
     ) {}
 
     ngOnInit(): void {
-        this.spindleReady$.pipe(
-            filter(ready => ready === true),
-            takeUntilDestroyed(this.destroyRef)
-        ).subscribe(() => this.stopStatus$.next());
+        this.spindleReady$
+            .pipe(
+                filter((ready) => ready === true),
+                takeUntilDestroyed(this.destroyRef),
+            )
+            .subscribe(() => this.stopStatus$.next());
 
         this.apiService.output$
             .pipe(takeUntilDestroyed(this.destroyRef))


### PR DESCRIPTION
We started using both `type_repr(...)` and `type_prefix(...)` and sent both to the frontend in the list view, but it turns out the Spindle view and sample detail view need it too. Without it, the type search simply won't work.

This PR makes sure `type` and `displayType` are returned to each page and uses the correct one for the `proof` pipe in the frontend for correct displaying of the results.