### PR TITLE
Fix button styling

### DIFF
--- a/frontend/src/app/spindle/export-button/export-button.component.html
+++ b/frontend/src/app/spindle/export-button/export-button.component.html
@@ -1,5 +1,5 @@
 <button
-    [class]="mode ? 'button ' + mode : 'button'"
+    [class]="getButtonClass(mode)"
     [class.is-loading]="isLoading"
     [class.with-text-below]="textBelow !== null"
     (click)="export.emit(mode ?? 'term-table')"

--- a/frontend/src/app/spindle/export-button/export-button.component.scss
+++ b/frontend/src/app/spindle/export-button/export-button.component.scss
@@ -27,7 +27,7 @@
     }
 }
 
-.latex {
+.latex-button {
     background-color: black;
     color: white;
 
@@ -36,17 +36,17 @@
     }
 }
 
-.overleaf {
+.overleaf-button {
     background-color: #47A141;
     color: white;
 }
 
-.pdf {
+.pdf-button {
     background-color: #FF0000;
     color: white;
 }
 
-.proof {
+.proof-button {
     background-color: #4444ca;
     color: white;
 }

--- a/frontend/src/app/spindle/export-button/export-button.component.ts
+++ b/frontend/src/app/spindle/export-button/export-button.component.ts
@@ -12,4 +12,8 @@ export class ExportButtonComponent {
     @Input() isLoading = false;
     @Input() buttonText = $localize`Export`;
     @Input() textBelow: string | null = null;
+
+    public getButtonClass(mode: SpindleMode | null): string {
+        return mode ? `button ${mode}-button` : "button";
+    }
 }


### PR DESCRIPTION
Tiny fix for the styling of the 'Export JSON' button. This button had the `proof` class, but this is now also used for the elements displaying the types.

Before:

![image](https://github.com/user-attachments/assets/f586c478-c176-4655-813d-ea9b2fb77761)

After:

![image](https://github.com/user-attachments/assets/aa944a2d-452c-4dc3-969f-c17638b1e0e1)
