### PR TITLE
Feature/sample batch load

### DIFF
--- a/backend/aethel_db/views/list.py
+++ b/backend/aethel_db/views/list.py
@@ -102,7 +102,9 @@ class AethelListResponse:
             )
 
         total_count = len(self.results)
-        paginated = list(self.results.values())[self.skip : self.skip + self.limit]
+        limit = min(self.limit, total_count)
+        skip = max(0, self.skip)
+        paginated = list(self.results.values())[skip : skip + limit]
         serialized = [result.serialize() for result in paginated]
 
         return JsonResponse(
@@ -130,13 +132,13 @@ class AethelListView(APIView):
                 error=AethelListError.INVALID_LIMIT_OR_SKIP
             ).json_response()
 
-        response_object = AethelListResponse(skip=skip, limit=limit)
-
         # We only search for strings of 3 or more characters.
         if word_input is not None and len(word_input) < 3:
             return AethelListResponse(
                 error=AethelListError.WORD_TOO_SHORT
             ).json_response()
+
+        response_object = AethelListResponse(skip=skip, limit=limit)
 
         try:
             parsed_type = parse_prefix(type_input) if type_input else None

--- a/backend/aethel_db/views/sample_data.py
+++ b/backend/aethel_db/views/sample_data.py
@@ -86,10 +86,7 @@ class AethelSampleDataView(APIView):
 
         word_input = json.loads(word_input)
 
-        try:
-            assert dataset is not None
-        except AssertionError:
-            # This should never happen.
+        if dataset is None:
             raise Exception("Dataset is not loaded.")
 
         # parse_prefix expects a type string with spaces.

--- a/backend/aethel_db/views/sample_data.py
+++ b/backend/aethel_db/views/sample_data.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict, dataclass, field
+from enum import Enum
 import json
 from django.http import HttpRequest, JsonResponse
 from rest_framework.views import APIView
@@ -20,6 +21,12 @@ class AethelSampleDataPhrase:
     highlight: bool
 
 
+class AethelSampleError(Enum):
+    INVALID_SKIP = "INVALID_SKIP"
+    INVALID_WORD = "INVALID_WORD"
+    NO_INPUT = "NO_INPUT"
+
+
 @dataclass
 class AethelSampleDataResult:
     name: str
@@ -32,10 +39,14 @@ class AethelSampleDataResult:
         return asdict(self)
 
 
+SAMPLE_LIMIT = 10
+
+
 @dataclass
 class AethelSampleDataResponse:
     results: list[AethelSampleDataResult] = field(default_factory=list)
-    error: str | None = None
+    error: AethelSampleError | None = None
+    skip: int = 0
 
     def get_or_create_result(self, sample: Sample) -> AethelSampleDataResult:
         """
@@ -55,9 +66,15 @@ class AethelSampleDataResponse:
         return new_result
 
     def json_response(self) -> JsonResponse:
+        total_count = len(self.results)
+        limit = min(SAMPLE_LIMIT, total_count)
+        skip = max(0, self.skip)
+        paginated = list(self.results)[skip : skip + limit]
+        serialized = [result.serialize() for result in paginated]
         return JsonResponse(
             {
-                "results": [r.serialize() for r in self.results],
+                "results": serialized,
+                "totalCount": total_count,
                 "error": self.error,
             },
             status=status.HTTP_200_OK,
@@ -68,30 +85,40 @@ class AethelSampleDataView(APIView):
     def get(self, request: HttpRequest) -> JsonResponse:
         type_input = self.request.query_params.get("type", None)
         word_input = self.request.query_params.get("word", None)
+        skip = self.request.query_params.get("skip", 0)
 
         response_object = AethelSampleDataResponse()
 
-        # Not expected.
-        if not type_input or not word_input:
+        error = self.validate_input(type_input, word_input, skip)
+
+        if error:
+            response_object.error = error
             return response_object.json_response()
+
+        response_object.skip = int(skip)
 
         word_input = json.loads(word_input)
 
-        assert dataset is not None
+        try:
+            assert dataset is not None
+        except AssertionError:
+            # This should never happen.
+            raise Exception("Dataset is not loaded.")
+
         # parse_prefix expects a type string with spaces.
         type_input = Type.parse_prefix(type_input, debug=True)
         by_type = dataset.by_type(str(type_input))  # re-serialize type to match index
         by_word = dataset.by_words(word_input)
         by_name = {sample.name: sample for sample in by_type + by_word}
         # we have to do the intersection by name because Samples are not hashable
-        intersection = set(s.name for s in by_type).intersection(set(s.name for s in by_word))
+        intersection = set(s.name for s in by_type).intersection(
+            set(s.name for s in by_word)
+        )
         samples = [by_name[name] for name in intersection]
 
         for sample in samples:
             for phrase_index, phrase in enumerate(sample.lexical_phrases):
-                word_match = match_word_with_phrase_exact(
-                    phrase, word_input
-                )
+                word_match = match_word_with_phrase_exact(phrase, word_input)
                 type_match = match_type_with_phrase(phrase, type_input)
 
                 if not (word_match and type_match):
@@ -102,3 +129,23 @@ class AethelSampleDataView(APIView):
                 aethel_sample.highlight_phrase_at_index(index=phrase_index)
 
         return response_object.json_response()
+
+    def validate_input(
+        self,
+        type_input: str | None,
+        word_input: str | None,
+        skip: str | int,
+    ) -> AethelSampleError | None:
+        try:
+            skip = int(skip)
+        except ValueError:
+            return AethelSampleError.INVALID_SKIP
+
+        try:
+            word_input = json.loads(word_input)
+        except json.JSONDecodeError:
+            return AethelSampleError.INVALID_WORD
+
+        if not type_input or not word_input:
+            # Not expected.
+            return AethelSampleError.NO_INPUT

--- a/frontend/src/app/aethel/sample-details/sample-data.component.html
+++ b/frontend/src/app/aethel/sample-details/sample-data.component.html
@@ -1,11 +1,9 @@
 <td colspan="5">
-    @if (loading) {
-    <p i18n>Loading samples...</p>
-    } @else {
-    <ul class="sample-list">
+    <ul class="sample-list mb-2">
         @for (sample of samples; track $index) {
         <li class="sample-item">
-            <p class="phrase-list">
+            <p>{{ $index + 1 }}</p>
+            <p class="phrase-list mx-2">
                 @for (phrase of sample.phrases; track phrase.index) {
                 <span [class.highlight]="phrase.highlight"
                     >{{ phrase.display }}
@@ -14,7 +12,7 @@
             </p>
             <a
                 [routerLink]="getSampleURL(sample.name)"
-                class="button is-primary ml-2"
+                class="button is-primary"
                 i18n
             >
                 Go to sample
@@ -22,5 +20,16 @@
         </li>
         }
     </ul>
+    @if (loading) {
+        <p i18n>Loading samples...</p>
+    }
+    @else if (!allSamplesLoaded()) {
+    <button
+        class="button button-primary"
+        type="button"
+        (click)="loadSamples()"
+    >
+        Load more
+    </button>
     }
 </td>

--- a/frontend/src/app/aethel/sample-details/sample-data.component.html
+++ b/frontend/src/app/aethel/sample-details/sample-data.component.html
@@ -1,6 +1,6 @@
 <td colspan="5">
     <ul class="sample-list mb-2">
-        @for (sample of samples(); track $index) {
+        @for (sample of visibleSamples(); track $index) {
         <li class="sample-item">
             <p>{{ $index + 1 }}</p>
             <p class="phrase-list mx-2">
@@ -27,7 +27,7 @@
     <button
         class="button button-primary"
         type="button"
-        (click)="loadSamples()"
+        (click)="loadMoreSamples()"
     >
         Load more
     </button>

--- a/frontend/src/app/aethel/sample-details/sample-data.component.html
+++ b/frontend/src/app/aethel/sample-details/sample-data.component.html
@@ -1,6 +1,6 @@
 <td colspan="5">
     <ul class="sample-list mb-2">
-        @for (sample of samples; track $index) {
+        @for (sample of samples(); track $index) {
         <li class="sample-item">
             <p>{{ $index + 1 }}</p>
             <p class="phrase-list mx-2">

--- a/frontend/src/app/aethel/sample-details/sample-data.component.scss
+++ b/frontend/src/app/aethel/sample-details/sample-data.component.scss
@@ -1,9 +1,12 @@
 
 .sample-item {
     display: flex;
-    justify-content: space-between;
     align-items: center;
     width: 100%;
+
+    a {
+        margin-left: auto;
+    }
 }
 
 .sample-item:not(:last-child) {

--- a/frontend/src/app/aethel/sample-details/sample-data.component.spec.ts
+++ b/frontend/src/app/aethel/sample-details/sample-data.component.spec.ts
@@ -62,7 +62,7 @@ describe("SampleDataComponent", () => {
         expect(req.request.method).toBe("GET");
         req.flush(mockResponse);
 
-        expect(component.samples).toEqual(mockResponse.results);
+        expect(component['samples']()).toEqual(mockResponse.results);
         expect(component.loading).toBeFalse();
     });
 

--- a/frontend/src/app/aethel/sample-details/sample-data.component.ts
+++ b/frontend/src/app/aethel/sample-details/sample-data.component.ts
@@ -19,7 +19,7 @@ import { environment } from "src/environments/environment";
 export class SampleDataComponent implements OnInit {
     @Input({ required: true }) aethelResult: AethelListResult | null = null;
 
-    public samples = signal<AethelSampleDataResult[]>([]);
+    public limit = signal<number>(10);
     public loading = false;
 
     // Hides the "Load More" button when all samples have been loaded.
@@ -27,8 +27,14 @@ export class SampleDataComponent implements OnInit {
         if (!this.aethelResult) {
             return false;
         }
-        return this.samples().length >= this.aethelResult.sampleCount;
+        return this.limit() >= this.samples().length;
     });
+
+    public visibleSamples = computed(() => {
+        return this.samples().slice(0, this.limit());
+    })
+
+    private samples = signal<AethelSampleDataResult[]>([]);
 
     constructor(
         private destroyRef: DestroyRef,
@@ -36,10 +42,6 @@ export class SampleDataComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        this.loadSamples();
-    }
-
-    public loadSamples(): void {
         if (!this.aethelResult) {
             return;
         }
@@ -60,6 +62,10 @@ export class SampleDataComponent implements OnInit {
             });
     }
 
+    public loadMoreSamples(): void {
+        this.limit.update(limit => limit + 10);
+    }
+
     public getSampleURL(sampleName: string): string[] {
         return ["sample", sampleName.replace(".xml", "")];
     }
@@ -70,7 +76,6 @@ export class SampleDataComponent implements OnInit {
                 aethelResult.phrase.items.map((item) => item.word),
             ),
             type: aethelResult.type,
-            skip: this.samples().length.toString(),
         };
         return queryParams;
     }


### PR DESCRIPTION
#75 should probably be merged first.

Potential fix for #52 

Mainly a UX improvement: adds a 'Load more' button that incrementally shows more results when the user clicks on it. I first implemented a 'skip' parameter to the query so it could retrieve up to 10 'new' results with every query. This improved performance in the sense that not every result needed to be serialized. On the other hand, it required queries to be re-executed every time the user clicked 'Load more'. For results with a large amount of samples (10000+), the user had to wait for 30 seconds for each batch.

For this reason, I decided to keep the old situation in which all results are retrieved in one go.