### PR TITLE
Feature: expose Spindle/LaTeX server ports on dev

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -77,6 +77,8 @@ services:
         image: pp-spindle-dev
         profiles: ["dev"]
         command: flask run --host 0.0.0.0 --port 32768
+        ports:
+            - "32768:32768"
 
     latex-prod: &latex-prod
         image: pp-latex-prod
@@ -96,6 +98,8 @@ services:
         image: pp-latex-dev
         profiles: ["dev"]
         command: flask run --host 0.0.0.0 --port 32769
+        ports:
+            - "32769:32769"
 
 networks:
     parseport:


### PR DESCRIPTION
Closes #32 

This will make reviewing a lot easier :)

Make sure to adjust your `settings.py` for this change to work:

```python
SPINDLE_URL = f"http://localhost:32768/"
LATEX_SERVICE_URL = f"http://localhost:32769/"
```