### PR TITLE
Fix: async worker in production build

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -162,7 +162,7 @@ services:
             - VULCAN_DEBUG=0
             - VULCAN_PORT=32771
         command: >
-            gunicorn -w 1 -b 0.0.0.0:32771 'app:create_app()'
+            gunicorn -k eventlet -w 1 -b 0.0.0.0:32771 'app:create_app()'
             --capture-output
             --access-logfile /logs/access_log
             --error-logfile /logs/error_log

--- a/nginx.conf
+++ b/nginx.conf
@@ -2,6 +2,12 @@ events { worker_connections 1024; }
 
 http {
     include /etc/nginx/mime.types;
+    
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Port $server_port;
+
     server {
         listen 80;
 


### PR DESCRIPTION
This is a reminder to always distrust my own code more than that of the backofficers.

This fixes the production build (currently on the acc server), on which Vulcan is very slow, throws errors and breaks down after a while. I thought this was due to the Apache configuration, but actually the command starting the `gunicorn` server in the prod build lacked the `-k eventlet` flag to handle asynchronous connections. This flag _was_ present in the dev build, which is why dev worked without a hitch.

The Nginx code is unrelated, but it came up during a meeting with the backoffice: it preserves the original host, protocol and port of the incoming request as it passes through the Apache/Nginx proxies. Basically, it tells the services in our Docker network where the original request is coming from (instead of simply 'Nginx'). This is not necessary for ParsePort at the moment, but it seems good practice, and with Kubernetes adding more and more layers in between the client and the actual servers in the future, it's best to get used to this host-forwarding thing.